### PR TITLE
Remove Jekyll's configuration file from the master branch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-cayman


### PR DESCRIPTION
This reverts commit 787b8aa90472778de15beaa2cbb11259ab9eb393.