### PR TITLE
Test if the type defining structure is generated (#4)

### DIFF
--- a/nl/Makefile
+++ b/nl/Makefile
@@ -2,7 +2,7 @@ all: old compiler tester
 
 compiler: compiler_nl compiler_gcc
 
-tester: tester_nl tester_gcc
+tester: tester_nl tester_gcc tester_gcc_pytest
 
 OBJDIR=obj
 OUT=mk_cache.exe
@@ -54,6 +54,9 @@ tester_nl:
 
 tester_gcc:
 	gcc ${CFLAGS} -o test_all test_all.c ${CACHETEST}/*.c ${NATIVE}/*.c -I${CACHETEST} -I${NATIVE} ${LINKS}
+
+tester_gcc_pytest:
+	python3 test/test_generated_struct.py
 
 tester_nl_js:
 	./${OUT} nianio_lib test --strict --o ${CACHETEST} --js --O2 --namespace instadb --profile

--- a/nl/test/test_generated_struct.nl
+++ b/nl/test/test_generated_struct.nl
@@ -1,0 +1,9 @@
+use ptd;
+
+def test_generated_struct::empty_function() {
+
+}
+
+def test_generated_struct::empty_struct() {
+    return ptd::rec({});
+}

--- a/nl/test/test_generated_struct.py
+++ b/nl/test/test_generated_struct.py
@@ -1,0 +1,24 @@
+import re
+
+def main():
+    print("\nGENERATED STRUCTS TESTS:")
+
+    file_ = open('cache_test/test_generated_struct.h', 'r')
+    contents = file_.read()
+
+    testnum = 1
+
+    def test(title, fun):
+        nonlocal testnum
+        print("\nTest {} - {}".format(testnum, title))
+        if fun():
+            print("PASSED\n");
+        else:
+            print("FAILED\n");
+        testnum = testnum + 1       
+
+
+    test("Empty struct", lambda: re.search(r"\s*struct\s*test_generated_struct0empty_struct0struct\s*\{\s*\};", contents))
+    test("Empty function is not a struct", lambda: not re.search(r"\s*struct\s*test_generated_struct0empty_function0struct\s*\{\s*\};", contents))
+
+main()

--- a/nl/test/test_generated_struct.py
+++ b/nl/test/test_generated_struct.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 def main():
     print("\nGENERATED STRUCTS TESTS:")
@@ -7,18 +8,22 @@ def main():
     contents = file_.read()
 
     testnum = 1
+    fail = False
 
     def test(title, fun):
-        nonlocal testnum
+        nonlocal testnum, fail
         print("\nTest {} - {}".format(testnum, title))
         if fun():
             print("PASSED\n");
         else:
             print("FAILED\n");
+            fail = True
         testnum = testnum + 1       
 
 
     test("Empty struct", lambda: re.search(r"\s*struct\s*test_generated_struct0empty_struct0struct\s*\{\s*\};", contents))
     test("Empty function is not a struct", lambda: not re.search(r"\s*struct\s*test_generated_struct0empty_function0struct\s*\{\s*\};", contents))
 
-main()
+    return (1 if fail else 0)
+
+sys.exit(main())


### PR DESCRIPTION
Stworzyłem skrypt w pythonie, w którym będziemy umieszczać testy.
Na początku testujemy tylko najprostszą rzecz - czy jest generowana struktura z pustej funkcji. Test powinien przechodzić nawet po rozszerzeniu implementacji generowania struktur.

Żeby test działał, trzeba uruchomić go w katalogu `nl/` tak jak robimy `make`.

Closes #4 