### PR TITLE
Int variables have INT type

### DIFF
--- a/nl/main.nl
+++ b/nl/main.nl
@@ -15,8 +15,14 @@ def main::main() {
 		arr => [{field => 1}, {field => 2}],
 	};
 
-	var i : ptd::int() = 1;
+	var i : ptd::int();
+	i = 4;
+	i = i + i;
+	var j : ptd::int();
+	j = 9;
+	j = j * i;
 
 	rec->arr[1]->field = 3;
 	nl::print(rec->arr[1]->field);
+	nl::print(j);
 }

--- a/nl/translator/interpreter.nl
+++ b/nl/translator/interpreter.nl
@@ -107,7 +107,7 @@ def build_state(labels : ptd::hash(@interpreter::module_labels_t), functions : p
 	known_exec_func : ptd::hash(@interpreter::known_exec_func_t)) : @interpreter::state_t {
 	return {
 			rstate => :error('nie wywolano funkcji'),
-			func => {annotation => :none, access => :priv, reg_size => 0, args_type => [], commands => [], name => '', defines_type => :no},
+			func => {annotation => :none, access => :priv, reg_size => 0, args_type => [], commands => [], name => '', defines_type => :no, variables => []}, #defines_type and variables fields not used
 			labels => labels,
 			functions => functions,
 			stack => [],

--- a/nl/translator/nlasm.nl
+++ b/nl/translator/nlasm.nl
@@ -32,6 +32,7 @@ def nlasm::function_t() {
 			commands => @nlasm::cmds_t,
 			name => ptd::sim(),
 			defines_type => ptd::var({no => ptd::none(), yes => @tct::meta_type}),
+			variables => ptd::arr(@nlasm::var_decl_t),
 		});
 }
 
@@ -99,8 +100,8 @@ def nlasm::order_t() {
 
 def nlasm::var_decl_t() {
 	return ptd::rec({
-		name => ptd::sim(), 
-		type => @tct::meta_type
+		type => @tct::meta_type,
+		register => @nlasm::reg_t
 	});
 }
 

--- a/nl/translator/translator.nl
+++ b/nl/translator/translator.nl
@@ -74,7 +74,8 @@ def translator::translate(ast : @nast::module_t) : @nlasm::result_t {
 					args_type => [],
 					commands => [],
 					name => function->name,
-					defines_type => function->defines_type
+					defines_type => function->defines_type,
+					variables => []
 				},
 				loop_label => {break => {label => '', logic => logic}, continue => {label => '', logic => logic}}
 			};
@@ -128,7 +129,7 @@ def print_var_decl(var_decl : @nast::variable_declaration_t, ref state : @transl
 	var reg = new_declaration(var_decl->name, ref state);
 	match (var_decl->tct_type) case :none {
 	} case :type(var tct_type) {
-		print(ref state, :var_decl({name => var_decl->name, type => tct_type}));
+		array::push(ref state->result->variables, {type => tct_type, register => reg});
 	}
 	match (var_decl->value) case :none {
 	} case :value(var value) {


### PR DESCRIPTION
Int variables have INT type. This automatically solves other issues. Works. Now our problems are:
1. GCC warns us about incompatible types.
2. Interpreter just ignores new fields of data structures (is that a problem?)
3. Maybe there's some ImmT - specific stuff happening. Needs to be checked if needs to be changed for INT.
4. Not all vars that are indeed ints are INTs. Let's think about it for a second.