### PR TITLE
Change array indexes to INT

### DIFF
--- a/nl/main.nl
+++ b/nl/main.nl
@@ -7,6 +7,9 @@ def main::main() {
 	i = 44;
 	var j : ptd::int() = 99;
 
+	var a = [1,2,3];
+	i = i + a[1];
+
 	i = i + i;
 	j = j * i;
 }

--- a/nl/native_lib_c/c_rt_lib.c
+++ b/nl/native_lib_c/c_rt_lib.c
@@ -1047,9 +1047,9 @@ ImmT c_rt_lib0array_new() {
 	return _array;
 }
 
-ImmT c_rt_lib0array_len(ImmT ___nl__arrI) {
+INT c_rt_lib0array_len(ImmT ___nl__arrI) {
 	if(!IS_ARR(___nl__arrI)) nl_die_internal("Array expected %s;", NAME(___nl__arrI));
-	return c_rt_lib0int_new(((NlArray *)___nl__arrI)->size);
+	return((NlArray *)___nl__arrI)->size;
 }
 
 NlArray* nl_array_internal_copy(ImmT ___nl__arrI) {
@@ -1158,9 +1158,9 @@ ImmT c_rt_lib0float_round(ImmT f) {
 	return c_rt_lib0float_new(number);
 }
 
-ImmT c_rt_lib0array_get(ImmT ___nl__arrI, ImmT ___nl__indexI) {
+ImmT c_rt_lib0array_get(ImmT ___nl__arrI, INT ___nl__indexI) {
 	NlArray *arr = (NlArray *)___nl__arrI;
-	INT index = getIntFromImm(___nl__indexI);
+	INT index = ___nl__indexI;
 	if (index < 0 || index >= arr->size)
 		nl_die_internal("array index %d out of range, array size: %d", index, arr->size);
 	ImmT ret = arr->arr[index];
@@ -1168,10 +1168,10 @@ ImmT c_rt_lib0array_get(ImmT ___nl__arrI, ImmT ___nl__indexI) {
 	return ret;
 }
 
-ImmT c_rt_lib0array_set(ImmT *___ref___arrI, ImmT ___nl__indexI, ImmT ___nl__el) {
+ImmT c_rt_lib0array_set(ImmT *___ref___arrI, INT ___nl__indexI, ImmT ___nl__el) {
 	if(!IS_ARR(*___ref___arrI)) nl_die_internal("Array expected %s;", NAME(*___ref___arrI));
 	NlArray *arr = priv_arr_to_change(___ref___arrI);
-	INT index = getIntFromImm(___nl__indexI);
+	INT index = ___nl__indexI;
 	if (index < 0 || index >= arr->size)
 		nl_die_internal("array index %d out of range, array size: %d", index, arr->size);
 	dec_ref(arr->arr[index]);
@@ -1424,7 +1424,7 @@ ImmT c_rt_lib0set_ref_hash(ImmT *___ref___hashI, ImmT ___nl__key, ImmT ___nl__va
 	return NULL;
 }
 
-ImmT c_rt_lib0get_ref_arr(ImmT ___nl__arrI, ImmT ___nl__indexI){
+ImmT c_rt_lib0get_ref_arr(ImmT ___nl__arrI, INT ___nl__indexI){
 	ImmT ret = c_rt_lib0array_get(___nl__arrI, ___nl__indexI);
 	if (REFS(___nl__arrI) == 1)
 		dec_ref(ret);

--- a/nl/native_lib_c/c_rt_lib.c
+++ b/nl/native_lib_c/c_rt_lib.c
@@ -1430,10 +1430,10 @@ ImmT c_rt_lib0get_ref_arr(ImmT ___nl__arrI, INT ___nl__indexI){
 		dec_ref(ret);
 	return ret;
 }
-ImmT c_rt_lib0set_ref_arr(ImmT *___ref___arrI, ImmT ___nl__indexI, ImmT ___nl__val){
+ImmT c_rt_lib0set_ref_arr(ImmT *___ref___arrI, INT ___nl__indexI, ImmT ___nl__val){
 	int many = REFS(*___ref___arrI) > 1;
 	NlArray *arr = priv_arr_to_change(___ref___arrI);
-	INT index = getIntFromImm(___nl__indexI);
+	INT index = ___nl__indexI;
 	if (index < 0 || index >= arr->size)
 		nl_die_internal("array index %d out of range, array size: %d", index, arr->size);
 	inc_ref(___nl__val);

--- a/nl/native_lib_c/c_rt_lib.h
+++ b/nl/native_lib_c/c_rt_lib.h
@@ -165,9 +165,9 @@ ImmT c_rt_lib0array_push(ImmT *arrI, ImmT el);
 ImmT c_rt_lib0array_new();
 ImmT c_rt_lib0array_mk(int nargs, ...);
 ImmT c_rt_lib0array_mk_dec(int nargs, ...);
-ImmT c_rt_lib0array_len(ImmT arrI);
-ImmT c_rt_lib0array_get(ImmT arrI, ImmT indexI);
-ImmT c_rt_lib0array_set(ImmT *arrI, ImmT indexI, ImmT el);
+INT c_rt_lib0array_len(ImmT arrI);
+ImmT c_rt_lib0array_get(ImmT arrI, INT indexI);
+ImmT c_rt_lib0array_set(ImmT *arrI, INT indexI, ImmT el);
 
 //types
 ImmT c_rt_lib0is_array(ImmT imm);
@@ -209,7 +209,7 @@ ImmT c_rt_lib0get_true();
 
 //ref arg
 ImmT c_rt_lib0get_ref_hash(ImmT hashI, ImmT keyI);
-ImmT c_rt_lib0get_ref_arr(ImmT arrI, ImmT indexI);
+ImmT c_rt_lib0get_ref_arr(ImmT arrI, INT indexI);
 ImmT c_rt_lib0set_ref_hash(ImmT *hashI, ImmT keyI, ImmT valI);
 ImmT c_rt_lib0set_ref_arr(ImmT *arrI, ImmT indexI, ImmT valI);
 

--- a/nl/native_lib_c/c_rt_lib.h
+++ b/nl/native_lib_c/c_rt_lib.h
@@ -211,7 +211,7 @@ ImmT c_rt_lib0get_true();
 ImmT c_rt_lib0get_ref_hash(ImmT hashI, ImmT keyI);
 ImmT c_rt_lib0get_ref_arr(ImmT arrI, INT indexI);
 ImmT c_rt_lib0set_ref_hash(ImmT *hashI, ImmT keyI, ImmT valI);
-ImmT c_rt_lib0set_ref_arr(ImmT *arrI, ImmT indexI, ImmT valI);
+ImmT c_rt_lib0set_ref_arr(ImmT *arrI, INT indexI, ImmT valI);
 
 //memory function
 void* alloc_mem(int size);

--- a/nl/native_lib_c/c_std_lib.c
+++ b/nl/native_lib_c/c_std_lib.c
@@ -58,7 +58,7 @@ ImmT c_std_lib0array_push(ImmT *___ref___arr, ImmT ___nl__el) {
 	return NULL;
 }
 
-ImmT c_std_lib0array_len(ImmT ___nl__arr) {
+INT c_std_lib0array_len(ImmT ___nl__arr) {
 	return c_rt_lib0array_len(___nl__arr);
 }
 ImmT c_std_lib0array_pop(ImmT *___ref___arr){

--- a/nl/native_lib_c/c_std_lib.h
+++ b/nl/native_lib_c/c_std_lib.h
@@ -13,7 +13,7 @@ ImmT c_std_lib0get_profile_global();
 ImmT c_std_lib0fast_substr(ImmT text_arr, ImmT begin, ImmT len);
 ImmT c_std_lib0array_sub(ImmT arr, ImmT begin, ImmT len);
 ImmT c_std_lib0array_push(ImmT *arr, ImmT el);
-ImmT c_std_lib0array_len(ImmT arr);
+INT c_std_lib0array_len(ImmT arr);
 ImmT c_std_lib0array_pop(ImmT *arr);
 ImmT c_std_lib0hash_get_value(ImmT hash, ImmT key);
 ImmT c_std_lib0hash_has_key(ImmT hash, ImmT key);

--- a/nl/translator/translator.nl
+++ b/nl/translator/translator.nl
@@ -931,7 +931,12 @@ def calc_val(value : @nast::value_t, ref state : @translator::state_t) : @nlasm:
 	if (value->value is :var) {
 		return get_var_register(value->value as :var, ref state);
 	}
-	var ready_value : @nlasm::reg_t = new_register(ref state, :im); #TODO set type
+	var ready_value : @nlasm::reg_t;
+	if (value->value is :const) {
+		ready_value = new_register(ref state, :int);
+	} else { 
+		ready_value = new_register(ref state, :im); #TODO set type
+	}
 	print_val(value, ready_value, ref state);
 	return ready_value;
 }


### PR DESCRIPTION
Closes #26 

Główną zmianą było ogarnięcie w translatorze generowania rejestrów intowych dla stałych.
Reszta to interfejs w runtime'ie (i test w main).